### PR TITLE
Добавив промпт. Переклав коментарі в Makefile. І чуть змінив README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Определяем компилятор и флаги
+# Визначаємо компілятор і прапори
 CC = aarch64-linux-gnu-gcc
 AS = aarch64-linux-gnu-as
 LD = aarch64-linux-gnu-ld
@@ -8,35 +8,35 @@ CFLAGS = -Wall -O2 -nostdlib -nostartfiles -ffreestanding -march=armv8-a
 ASFLAGS = #
 LDFLAGS = -nostdlib -T memmap
 
-# Исходные файлы
+# Вихідні файли
 SRC_C = notmain.c uart.c strings.c editor.c file_system.c
 SRC_ASM = strap.s
 OBJ = $(SRC_C:.c=.o) $(SRC_ASM:.s=.o)
 
-# Целевой файл
+# Цільовий файл
 TARGET = os.elf
 BINARY = os.bin
 
-# Правило по умолчанию
+# Правило за замовчуванням
 all: $(TARGET) $(BINARY)
 
-# Правило компиляции C файлов
+# Правило компіляції C файлів
 %.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-# Правило ассемблерных файлов
+# Правило асемблерних файлів
 %.o: %.s
 	$(AS) $(ASFLAGS) -o $@ $<
 
-# Линковка объектов
+# Лінкування об'єктів
 $(TARGET): $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $^
 
-# Конвертация в бинарный формат
+# Конвертація в бінарний формат
 $(BINARY): $(TARGET)
 	$(OBJCOPY) -O binary -R .fuse $< $@
 
-# Очистка
+# Очищення
 clean:
 	rm -f $(OBJ) $(TARGET) $(BINARY)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ sudo apt install build-essential aarch64-linux-gnu qemu-system-arm
 
 > qemu-system-aarch64 -M virt -cpu cortex-a53 -m 128 -serial mon:stdio -kernel os.bin
 
+або
+> qemu-system-aarch64 -M virt -cpu cortex-a53 -m 128 -serial mon:stdio -kernel os.bin -nographic
+
 
 ### Плани розробки
 - [ ] команда version

--- a/notmain.c
+++ b/notmain.c
@@ -13,8 +13,9 @@ void notmain(void){
 	char command_history[COMMAND_HISTORY_SiZE][100];
 	int command_history_count = 0;
 	int command_history_pos = -1;
-	uart_puts("UART test... \n");
+	uart_puts("UART test OS is ready!");
 	init_fs();
+	uart_puts("\r\n:: ");
 	while(1){
 		c = uart_getc();
 		if(c == '\r'){
@@ -33,6 +34,7 @@ void notmain(void){
 			print_command(command, debug_mode);
 			process_command(command, &debug_mode);
 			index = 0;
+			uart_puts("\r\n:: ");
 		} else if (c == '\b' || c == 127){
 			if(index > 0){
 				index--;


### PR DESCRIPTION
Я думаю що буде чуть, але красивіше виглядати термінал з промптом.
За `Makefile` то просто захотілось перекласти коментарі.
А що я додав в `README.md`?
Добавив ту же команду з `-nographic` щоб не було такого:
---
```
$ qemu-system-aarch64 -M virt -cpu cortex-a53 -m 128 -serial mon:stdio -kernel os.bin
qemu: module ui-ui-gtk not found, do you want to install qemu-system-gui package?
qemu: module ui-ui-sdl not found, do you want to install qemu-system-gui package?
VNC server running on ::1:5900
UART test OS is ready!
:: 
```
з `-nographic`:
```
$ qemu-system-aarch64 -M virt -cpu cortex-a53 -m 128 -serial mon:stdio -kernel os.bin -nographic
UART test OS is ready!
:: 
```
---
Ну у мене таке, бо я працюю не через WSL (напевно)